### PR TITLE
Fix flaky test failure in ConfigurationAsmGeneratorTest#testPolymorphicErrors

### DIFF
--- a/modules/configuration-api/src/main/java/org/apache/ignite/configuration/annotation/PolymorphicConfig.java
+++ b/modules/configuration-api/src/main/java/org/apache/ignite/configuration/annotation/PolymorphicConfig.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *
  * <p>To change the type of polymorphic configuration, you must use the {@code PolymorphicConfigChange#convert}.
  *
- * <p>NOTE: {@link PolymorphicId} field must go first, you should explicitly declare that, also at least one
+ * <p>NOTE: {@link PolymorphicId} field must be present, you should explicitly declare that, also at least one
  * {@link PolymorphicConfigInstance} is required.
  */
 @Target(TYPE)

--- a/modules/configuration-api/src/main/java/org/apache/ignite/configuration/annotation/PolymorphicId.java
+++ b/modules/configuration-api/src/main/java/org/apache/ignite/configuration/annotation/PolymorphicId.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * This annotation marks the {@link PolymorphicConfig polymorphic configuration schema} field as a special (read only) leaf that will store
  * the current {@link PolymorphicConfigInstance#value polymorphic configuration type}.
  *
- * <p>NOTE: Field must be the first in the schema, and the type must be {@link String}.
+ * <p>NOTE: Field type must be {@link String}.
  */
 @Target(FIELD)
 @Retention(RUNTIME)

--- a/modules/configuration/README.md
+++ b/modules/configuration/README.md
@@ -118,7 +118,7 @@ public static class AbstractConfigurationSchema {
   has been provided explicitly. This annotation can only be present on fields of the Java primitive or `String` type.
     
   All _leaves_ must be public and corresponding configuration values **must not be null**;
-* `@PolymorphicId` is similar to the `@Value`, but is used to store the type of polymorphic configuration (`@PolymorphicConfigInstance#value`), must be a `String` and placed as the first field in a schema;
+* `@PolymorphicId` is similar to the `@Value`, but is used to store the type of polymorphic configuration (`@PolymorphicConfigInstance#value`) and must be a `String`.
 * `@Immutable` annotation can only be present on fields marked with the `@Value` annotation. Annotated fields cannot be 
   changed after they have been initialized (either manually or by assigning a default value).
 

--- a/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/asm/ConfigurationAsmGenerator.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/asm/ConfigurationAsmGenerator.java
@@ -1246,7 +1246,7 @@ public class ConfigurationAsmGenerator {
             );
         } else if (!polymorphicFieldsByExtension.isEmpty()) {
             assert polymorphicTypeIdFieldDef != null : schemaClass.getName();
-            assert isPolymorphicId(schemaFields.get(0)) : schemaClass.getName();
+            assert schemaFields.stream().anyMatch(ConfigurationUtil::isPolymorphicId) : schemaClass.getName();
 
             // Create switch by polymorphicTypeIdField.
             StringSwitchBuilder switchBuilderTypeId = typeIdSwitchBuilder(traverseChildrenMtd, polymorphicTypeIdFieldDef);

--- a/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/asm/ConfigurationAsmGenerator.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/asm/ConfigurationAsmGenerator.java
@@ -1246,7 +1246,8 @@ public class ConfigurationAsmGenerator {
             );
         } else if (!polymorphicFieldsByExtension.isEmpty()) {
             assert polymorphicTypeIdFieldDef != null : schemaClass.getName();
-            assert schemaFields.stream().anyMatch(ConfigurationUtil::isPolymorphicId) : schemaClass.getName();
+            assert schemaFields.stream().anyMatch(ConfigurationUtil::isPolymorphicId) :
+                    "Missing field with @PolymorphicId in " + schemaClass.getName();
 
             // Create switch by polymorphicTypeIdField.
             StringSwitchBuilder switchBuilderTypeId = typeIdSwitchBuilder(traverseChildrenMtd, polymorphicTypeIdFieldDef);


### PR DESCRIPTION
### What is the purpose of this PR

- This PR fixes the flaky test `org.apache.ignite.internal.configuration.asm.ConfigurationAsmGeneratorTest.testPolymorphicErrors`
- The mentioned test may fail or pass without changes made to the source code when it is run in different JVMs due to `Class#getDeclaredFields`'s non-deterministic output order.

### Why the test fails

- According to [Java documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--) about `getDeclaredFields`, returned array are not sorted and are not in any particular order.
- `ConfigurationUtil#schemaFields()` uses `getDeclaredFields` to return the list of schema fields. This list is passed to `ConfigurationAsmGenerator#createNodeClass()` and then passed to `ConfigurationAsmGenerator#addNodeTraverseChildrenMethod()`.  In this method at line 1249, there is an assertion to check if `schemaFields.get(0)` is PolymorphicId, but due to the non-deterministic order of this list, the first index of the list might not be PolymorphicId and assertion fails.

### Reproduce the test failure

- Run the test with 'NonDex' maven plugin. The command to recreate the flaky test failure is `mvn edu.illinois:nondex-maven-plugin:2.1-SNAPSHOT:nondex -pl modules/configuration -Dtest=ConfigurationAsmGeneratorTest#testPolymorphicErrors`
- Fixing the flaky test now, will prevent flaky test failures in future Java versions.

### Expected Result

- The tests should run successfully when run with 'NonDex' maven with the same command for recreating the flaky test.

### Actual Result

- We get the following error:
```
[INFO] Running org.apache.ignite.internal.configuration.asm.ConfigurationAsmGeneratorTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.107 s <<< FAILURE! - in org.apache.ignite.internal.configuration.asm.ConfigurationAsmGeneratorTest
[ERROR] org.apache.ignite.internal.configuration.asm.ConfigurationAsmGeneratorTest.testPolymorphicErrors  Time elapsed: 0.085 s  <<< FAILURE!
java.lang.AssertionError: org.apache.ignite.internal.configuration.asm.ConfigurationAsmGeneratorTest$PolymorphicNamedTestConfigurationSchema
        at org.apache.ignite.internal.configuration.asm.ConfigurationAsmGeneratorTest.beforeEach(ConfigurationAsmGeneratorTest.java:110)

```

### Fix

- Instead of checking `ConfigurationUtil#isPolymorphicId` on the first element of `schemaFields`, use `schemaFields.stream().anyMatch` to check the whole list.
